### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/control_methods/no_denoising/config.vsh.yaml
+++ b/src/control_methods/no_denoising/config.vsh.yaml
@@ -16,7 +16,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners:
   - type: executable

--- a/src/control_methods/perfect_denoising/config.vsh.yaml
+++ b/src/control_methods/perfect_denoising/config.vsh.yaml
@@ -17,7 +17,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
 
 runners:
   - type: executable

--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -29,7 +29,7 @@ resources:
   - path: helper.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/alra/config.vsh.yaml
+++ b/src/methods/alra/config.vsh.yaml
@@ -35,7 +35,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         cran: [ Matrix, rsvd ]

--- a/src/methods/knn_smoothing/config.vsh.yaml
+++ b/src/methods/knn_smoothing/config.vsh.yaml
@@ -33,7 +33,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages:

--- a/src/methods/magic/config.vsh.yaml
+++ b/src/methods/magic/config.vsh.yaml
@@ -55,7 +55,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pip: [scprep, magic-impute, scipy, scikit-learn<1.2, numpy<2]

--- a/src/methods/saver/config.vsh.yaml
+++ b/src/methods/saver/config.vsh.yaml
@@ -25,7 +25,7 @@ resources:
     path: script.R
 engines:
   - type: docker
-    image: openproblems/base_r:1.0.0
+    image: openproblems/base_r:1
     setup:
       - type: r
         github: mohuangx/SAVER

--- a/src/methods/scprint/config.vsh.yaml
+++ b/src/methods/scprint/config.vsh.yaml
@@ -67,7 +67,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_pytorch_nvidia:1.0.0
+    image: openproblems/base_pytorch_nvidia:1
     setup:
       - type: python
         pip:

--- a/src/metrics/mse/config.vsh.yaml
+++ b/src/metrics/mse/config.vsh.yaml
@@ -19,7 +19,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/metrics/poisson/config.vsh.yaml
+++ b/src/metrics/poisson/config.vsh.yaml
@@ -19,7 +19,7 @@ resources:
     path: script.py
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: 


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.