### PR TITLE
Fix: Correct argument order in poisson_nll_loss function call

### DIFF
--- a/src/metrics/poisson/script.py
+++ b/src/metrics/poisson/script.py
@@ -31,7 +31,7 @@ denoised_data = denoised_data * target_sum / initial_sum
 def poisson_nll_loss(y_pred: np.ndarray, y_true: np.ndarray) -> float:
     return (y_pred - y_true * np.log(y_pred + 1e-6)).mean()
 
-error = poisson_nll_loss(test_data, denoised_data)
+error = poisson_nll_loss(denoised_data, test_data)
 
 print("Store poisson value", flush=True)
 output = ad.AnnData(


### PR DESCRIPTION
## Describe your changes

Fixed a bug in the Poisson negative log-likelihood metric calculation where the arguments to `poisson_nll_loss()` were swapped.

- Swapped `test_data` and `denoised_data` arguments to match function signature
- `y_pred` should be `denoised_data` (prediction)
- `y_true` should be `test_data` (ground truth)
- This bug was causing incorrect metric values

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [ ] New functionality
  - [ ] Major changes
  - [x] Minor changes
  - [x] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!